### PR TITLE
Updated to support mongo client v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - MONGODB_VERSION="3.2.5"
   - MONGODB_VERSION="3.0.11"
   - MONGODB_VERSION="2.6.12"
+  - MONGODB_VERSION="3.6.3"
 
 before_install:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: node_js
+
 sudo: false
+
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
+  - "8"
+  - "9"
+
 env:
   - MONGODB_VERSION="3.2.5"
   - MONGODB_VERSION="3.0.11"
   - MONGODB_VERSION="2.6.12"
+
 before_install:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
   - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ MongoClient.connect(url, { w: 1 }, function (err, client) {
 })
 ```
 
+Promises and *async await* are supported as well.
+```js
+var clean = require('mongo-clean')
+var MongoClient = require('mongodb').MongoClient
+var url = "mongodb://localhost:27017"
+
+MongoClient.connect(url, { w: 1 }, function (err, client) {
+  clean(client.db('mongocleantest'))
+    .then(console.log)
+    .catch(console.log)
+})
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ npm install mongo-clean --save-dev
 
 ## Usage
 
-Reusing the same client:
+Pass the database handler to `clean`.
 
 ```js
 var clean = require('mongo-clean')
 var MongoClient = require('mongodb').MongoClient
-var url = "mongodb://localhost:27017/mongocleantest"
+var url = "mongodb://localhost:27017"
 
 MongoClient.connect(url, { w: 1 }, function (err, client) {
   clean(client.db('mongocleantest'), function (err) {
@@ -28,39 +28,17 @@ MongoClient.connect(url, { w: 1 }, function (err, client) {
 })
 ```
 
-Creating a new client:
-
-```js
-var clean = require('mongo-clean')
-var url = "mongodb://localhost:27017/mongocleantest"
-
-clean(url, function (err, db, client) {
-  // automatically does MongoClient.connect for you
-  // your db is clean!
-})
-```
-
 Clean the db excluding a list of collections
 
 ```js
 var clean = require('mongo-clean')
 var MongoClient = require('mongodb').MongoClient
-var url = "mongodb://localhost:27017/mongocleantest"
+var url = "mongodb://localhost:27017"
 
 MongoClient.connect(url, { w: 1 }, function (err, client) {
-  clean(client.db('mongocleantest'), {exclude: ['dummy1', 'dummy2']}, function () {
+  clean(client.db('mongocleantest'), {exclude: ['dummy1', 'dummy2']}, function (err) {
     // Delete all the collections in the db except dummy1 and dummy2
   })
-})
-```
-
-```js
-var clean = require('mongo-clean')
-var url = "mongodb://localhost:27017/mongocleantest"
-
-clean(url, {exclude: ['dummy1', 'dummy2']}, function (err, db, client) {
-  // automatically does MongoClient.connect for you
-  // Delete all the collections in the db except dummy1 and dummy2
 })
 ```
 
@@ -68,10 +46,13 @@ Removing all elements instead of dropping the collections:
 
 ```js
 var clean = require('mongo-clean')
-var url = "mongodb://localhost:27017/mongocleantest"
+var MongoClient = require('mongodb').MongoClient
+var url = "mongodb://localhost:27017"
 
-clean(url, { action: 'remove' }, function (err, db, client) {
-  // automatically removes all the data from all the collections in the db
+MongoClient.connect(url, { w: 1 }, function (err, client) {
+  clean(client.db('mongocleantest'), { action: 'remove' }, function (err) {
+    // automatically removes all the data from all the collections in the db
+  })
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ var clean = require('mongo-clean')
 var MongoClient = require('mongodb').MongoClient
 var url = "mongodb://localhost:27017/mongocleantest"
 
-MongoClient.connect(url, { w: 1 }, function (err, db) {
-  clean(db, function () {
+MongoClient.connect(url, { w: 1 }, function (err, client) {
+  clean(client.db('mongocleantest'), function (err) {
     // your db is clean!
   })
 })
@@ -34,7 +34,7 @@ Creating a new client:
 var clean = require('mongo-clean')
 var url = "mongodb://localhost:27017/mongocleantest"
 
-clean(url, function (err, db) {
+clean(url, function (err, db, client) {
   // automatically does MongoClient.connect for you
   // your db is clean!
 })
@@ -47,8 +47,8 @@ var clean = require('mongo-clean')
 var MongoClient = require('mongodb').MongoClient
 var url = "mongodb://localhost:27017/mongocleantest"
 
-MongoClient.connect(url, { w: 1 }, function (err, db) {
-  clean(db, {exclude: ['dummy1', 'dummy2']}, function () {
+MongoClient.connect(url, { w: 1 }, function (err, client) {
+  clean(client.db('mongocleantest'), {exclude: ['dummy1', 'dummy2']}, function () {
     // Delete all the collections in the db except dummy1 and dummy2
   })
 })
@@ -58,7 +58,7 @@ MongoClient.connect(url, { w: 1 }, function (err, db) {
 var clean = require('mongo-clean')
 var url = "mongodb://localhost:27017/mongocleantest"
 
-clean(url, {exclude: ['dummy1', 'dummy2']}, function (err, db) {
+clean(url, {exclude: ['dummy1', 'dummy2']}, function (err, db, client) {
   // automatically does MongoClient.connect for you
   // Delete all the collections in the db except dummy1 and dummy2
 })
@@ -70,7 +70,7 @@ Removing all elements instead of dropping the collections:
 var clean = require('mongo-clean')
 var url = "mongodb://localhost:27017/mongocleantest"
 
-clean(url, { action: 'remove' }, function (err, db) {
+clean(url, { action: 'remove' }, function (err, db, client) {
   // automatically removes all the data from all the collections in the db
 })
 ```

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const steed = require('steed')()
 
 function clean (db, options, done) {
   var exclude = []
+  options = options || {}
   if (arguments.length === 2) { // if only two arguments were supplied
     if (typeof options === 'function') {
       done = options
@@ -13,6 +14,13 @@ function clean (db, options, done) {
     if ('exclude' in options) {
       exclude = options.exclude
     }
+  }
+  if (typeof done !== 'function') {
+    return new Promise((resolve, reject) => {
+      clean(db, options, (err, db) => {
+        err ? reject(err) : resolve(db)
+      })
+    })
   }
   var action = options.action || 'drop'
   steed.waterfall([

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Clean a Mongo database",
   "main": "index.js",
   "scripts": {
+    "mongo": "docker run --rm -p 27017:27017 mongo:3.6",
     "test": "standard && tape test.js | tap-spec"
   },
   "precommit": "test",
@@ -23,12 +24,12 @@
   },
   "homepage": "https://github.com/mcollina/mongo-clean",
   "devDependencies": {
-    "mongodb": "^2.0.47",
-    "pre-commit": "^1.1.2",
-    "semver": "^5.1.0",
-    "standard": "^5.3.1",
-    "tap-spec": "^4.1.0",
-    "tape": "^4.2.0"
+    "mongodb": "^3.0.5",
+    "pre-commit": "^1.2.2",
+    "semver": "^5.5.0",
+    "standard": "^11.0.1",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.9.0"
   },
   "dependencies": {
     "steed": "^1.1.3"

--- a/test.js
+++ b/test.js
@@ -134,3 +134,40 @@ test('removes all the content from a collection', function (t) {
     })
   })
 })
+
+test('does nothing on an empty db (with promises)', function (t) {
+  getDB(function (err, client, db) {
+    t.notOk(err, 'no error')
+
+    clean(db)
+      .then(db => close(client, t))
+      .catch(err => {
+        t.error(err)
+        close(client, t)
+      })
+  })
+})
+
+test('removes a collection (with promises)', function (t) {
+  getDB(function (err, client, db) {
+    t.notOk(err, 'no error')
+
+    // creates collection dummy1
+    db.createCollection('dummy1', function (err) {
+      t.notOk(err, 'no error')
+
+      clean(db)
+        .then(db => {
+          db.listCollections({}).toArray(function (err, collections) {
+            t.notOk(err, 'no error')
+            t.equal(collections.length, baseCount + 0)
+            close(client, t)
+          })
+        })
+        .catch(err => {
+          t.error(err)
+          close(client, t)
+        })
+    })
+  })
+})

--- a/test.js
+++ b/test.js
@@ -9,42 +9,50 @@ var url = 'mongodb://localhost:27017/mongocleantest'
 var baseCount = !process.env.MONGODB_VERSION || semver.satisfies(process.env.MONGODB_VERSION, '>= 3.2.0') ? 0 : 1
 
 function getDB (cb) {
-  MongoClient.connect(url, { w: 1 }, cb)
+  MongoClient.connect(url, { w: 1 }, (err, client) => {
+    if (err) return cb(err, null)
+    cb(null, client, client.db('mongocleantest'))
+  })
 }
 
-function close (db, t) {
-  db.close(function () {
+function close (client, t) {
+  client.close(function () {
     t.end()
   })
 }
 
-function cleanVerifyAndClose (db, t) {
-  clean(db, function (err, db) {
+function cleanVerifyAndClose (client, db, t) {
+  clean(db, function (err, cleanDb, cleanClient) {
     t.notOk(err, 'no error')
 
-    db.listCollections({}).toArray(function (err, collections) {
+    var dbSwap = typeof db === 'string' ? cleanDb : db
+    dbSwap.listCollections({}).toArray(function (err, collections) {
       t.notOk(err, 'no error')
 
       t.equal(collections.length, baseCount + 0)
 
-      close(db, t)
+      if (typeof db === 'string') {
+        close(cleanClient, t)
+      } else {
+        close(client, t)
+      }
     })
   })
 }
 
 test('does nothing on an empty db', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     clean(db, function (err) {
       t.notOk(err, 'no error')
-      close(db, t)
+      close(client, t)
     })
   })
 })
 
 test('removes a collection', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     // creates collection dummy1
@@ -52,13 +60,13 @@ test('removes a collection', function (t) {
       t.notOk(err, 'no error')
 
       // clean, verify and close
-      cleanVerifyAndClose(db, t)
+      cleanVerifyAndClose(client, db, t)
     })
   })
 })
 
 test('removes two collections', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     db.createCollection('dummy1', function (err) {
@@ -68,29 +76,29 @@ test('removes two collections', function (t) {
         t.notOk(err, 'no error')
 
         // clean, verify and close
-        cleanVerifyAndClose(db, t)
+        cleanVerifyAndClose(client, db, t)
       })
     })
   })
 })
 
 test('clean using an url', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     // creates collection dummy1
     db.createCollection('dummy3', function (err) {
       t.notOk(err, 'no error')
 
-      db.close(function () {
-        cleanVerifyAndClose(url, t)
+      client.close(function () {
+        cleanVerifyAndClose(client, url, t)
       })
     })
   })
 })
 
 test('removes two collections on three', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     db.createCollection('dummy1', function (err) {
@@ -112,7 +120,7 @@ test('removes two collections on three', function (t) {
 
               t.equal(collections.length, baseCount + 1)
 
-              close(db, t)
+              close(client, t)
             })
           })
         })
@@ -122,7 +130,7 @@ test('removes two collections on three', function (t) {
 })
 
 test('removes two collections on four connecting via url', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     db.createCollection('dummy1', function (err) {
@@ -134,16 +142,16 @@ test('removes two collections on four connecting via url', function (t) {
         db.createCollection('dummy3', function (err) {
           t.notOk(err, 'no error')
 
-          db.close(function () {
-            clean(url, {exclude: ['dummy1', 'dummy2']}, function (err, db) {
+          client.close(function () {
+            clean(url, {exclude: ['dummy1', 'dummy2']}, function (err, cleanDb, cleanClient) {
               t.notOk(err, 'no error')
 
-              db.listCollections({}).toArray(function (err, collections) {
+              cleanDb.listCollections({}).toArray(function (err, collections) {
                 t.notOk(err, 'no error')
 
                 t.equal(collections.length, baseCount + 2)
 
-                close(db, t)
+                close(cleanClient, t)
               })
             })
           })
@@ -154,7 +162,7 @@ test('removes two collections on four connecting via url', function (t) {
 })
 
 test('removes all the content from a collection', function (t) {
-  getDB(function (err, db) {
+  getDB(function (err, client, db) {
     t.notOk(err, 'no error')
 
     clean(db, function (err, db) {
@@ -171,7 +179,7 @@ test('removes all the content from a collection', function (t) {
               coll.find().count(function (err, count) {
                 t.error(err)
                 t.equal(count, 0, 'no elements in the collection')
-                close(db, t)
+                close(client, t)
               })
             })
           })


### PR DESCRIPTION
As titled, update also all the dependencies.
This is a breaking change.
If an url is passed instead of the db connection `mongo-clean` will also return the client to allow the user to close the connection.